### PR TITLE
fix: make sure `Th` components have `Tr` parents

### DIFF
--- a/src/app/(main)/(billing)/billing/[id]/BillingDetailsItemsTable.tsx
+++ b/src/app/(main)/(billing)/billing/[id]/BillingDetailsItemsTable.tsx
@@ -41,10 +41,12 @@ export default function BillingDetailsItemsTable({
     <TableContainer {...tableProps}>
       <Table>
         <Thead>
-          <Th>Name</Th>
-          <Th>Price</Th>
-          <Th>Quantity</Th>
-          <Th>Amount</Th>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Price</Th>
+            <Th>Quantity</Th>
+            <Th>Amount</Th>
+          </Tr>
         </Thead>
 
         <Tbody>

--- a/src/app/(main)/(billing)/billing/create/input/BillingItemTable.tsx
+++ b/src/app/(main)/(billing)/billing/create/input/BillingItemTable.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Table, TableContainer, Tbody, Th, Thead } from '@chakra-ui/react'
+import { Table, TableContainer, Tbody, Th, Thead, Tr } from '@chakra-ui/react'
 import BillingItemTableRow from './BillingItemTableRow'
 import { produce } from 'immer'
 import { Billing, BillingItem } from '@/types/Billing'
@@ -80,11 +80,13 @@ export default function BillingItemTable({
       <TableContainer>
         <Table data-cy="items-table">
           <Thead>
-            <Th>Name</Th>
-            <Th>Price</Th>
-            <Th>Quantity</Th>
-            <Th>Amount</Th>
-            <Th />
+            <Tr>
+              <Th>Name</Th>
+              <Th>Price</Th>
+              <Th>Quantity</Th>
+              <Th>Amount</Th>
+              <Th />
+            </Tr>
           </Thead>
 
           <Tbody>


### PR DESCRIPTION
Resolves warnings thrown in the console regarding tr being a direct child of `thead`, instead of being a child of `tr`