### PR TITLE
fix: recover from session invalidation

### DIFF
--- a/cypress/e2e/session-invalidated.cy.ts
+++ b/cypress/e2e/session-invalidated.cy.ts
@@ -1,12 +1,12 @@
 describe('session invalidated', () => {
-  it('supports mid-session invalidation flow', () => {
+  it('handles mid-session invalidation when navigating to protected route', () => {
     // test path choice was arbitrary
     cy.visit('/billing/create')
     // just to smoke-test that the user has been logged in
     cy.location('pathname').should('equal', '/billing/create')
 
     cy.setCookie('token', 'now invalidated')
-    cy.reload()
+    cy.reload() // equivalent to navigating to a protected route since you're reloading /billing/create
 
     cy.location('pathname').should('equal', '/login')
 

--- a/cypress/e2e/session-invalidated.cy.ts
+++ b/cypress/e2e/session-invalidated.cy.ts
@@ -16,4 +16,21 @@ describe('session invalidated', () => {
 
     cy.location('pathname').should('not.equal', '/login')
   })
+
+  it('handles mid-session invalidation with manual navigation to login', () => {
+    // test path choice was arbitrary
+    cy.visit('/billing/create')
+    // just to smoke-test that the user has been logged in
+    cy.location('pathname').should('equal', '/billing/create')
+
+    cy.setCookie('token', 'now invalidated')
+    cy.visit('/login')
+    cy.location('pathname').should('equal', '/login')
+
+    cy.dataCy('username').type('root')
+    cy.dataCy('password').type('password')
+    cy.dataCy('submit').click()
+
+    cy.location('pathname').should('not.equal', '/login')
+  })
 })

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "react-thermal-printer": "^0.16.0",
     "react-use": "^17.4.2",
     "react-webcam": "^7.2.0",
-    "sprintf-js": "^1.1.3",
-    "url-pattern": "^1.0.3"
+    "sprintf-js": "^1.1.3"
   },
   "devDependencies": {
     "@types/howler": "^2.2.11",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "html-to-image": "^1.11.11",
     "immer": "^10.0.3",
     "jose": "^5.0.1",
-    "js-cookie": "^3.0.5",
     "jsbarcode": "^3.11.6",
     "lodash": "^4.17.21",
     "next": "13.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ dependencies:
   jose:
     specifier: ^5.0.1
     version: 5.0.1
-  js-cookie:
-    specifier: ^3.0.5
-    version: 3.0.5
   jsbarcode:
     specifier: ^3.11.6
     version: 3.11.6
@@ -3837,11 +3834,6 @@ packages:
 
   /js-cookie@2.2.1:
     resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
-    dev: false
-
-  /js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
     dev: false
 
   /js-tokens@4.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ dependencies:
   sprintf-js:
     specifier: ^1.1.3
     version: 1.1.3
-  url-pattern:
-    specifier: ^1.0.3
-    version: 1.0.3
 
 devDependencies:
   '@types/howler':
@@ -5341,11 +5338,6 @@ packages:
       querystringify: 2.2.0
       requires-port: 1.0.0
     dev: true
-
-  /url-pattern@1.0.3:
-    resolution: {integrity: sha512-uQcEj/2puA4aq1R3A2+VNVBgaWYR24FdWjl7VNW83rnWftlhyzOZ/tBjezRiC2UkIzuxC8Top3IekN3vUf1WxA==}
-    engines: {node: '>=0.12.0'}
-    dev: false
 
   /use-callback-ref@1.3.0(@types/react@18.2.33)(react@18.2.0):
     resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,30 +4,41 @@ import { RedirectType, redirect } from 'next/navigation'
 import { DEFAULT_ROUTE } from '@/app/default-route'
 import { apiFetch } from '@/server-utils/resource-api-util'
 import { cookies } from 'next/headers'
-import { FetchError } from '@/utils/fetch-utils'
+import { ApiResponse, FetchError } from '@/utils/fetch-utils'
 import { Credentials } from '@/types/login-types'
 
 export default async function Login() {
   async function authenticate(credentials: Credentials) {
     'use server'
 
-    try {
-      const response = await apiFetch('/authenticate', {
+    /*
+     * Can't use try-catch here because of this weird Next bug:
+     * https://github.com/vercel/next.js/issues/49298#issuecomment-1649261356
+     */
+
+    const result: Error | ApiResponse<undefined> = await apiFetch(
+      '/authenticate',
+      {
         method: 'POST',
         body: JSON.stringify(credentials),
         headers: {
           'Content-Type': 'application/json',
         },
-      })
-
-      cookies().set('token', await response.text())
-      redirect(DEFAULT_ROUTE)
-    } catch (e) {
-      if (e instanceof FetchError) {
-        redirect(`/login?authError=${e.response.status}`, RedirectType.replace)
       }
+    )
+      .then((res) => res)
+      .catch((err) => err)
 
+    if (result instanceof FetchError) {
+      redirect(
+        `/login?authError=${result.response.status}`,
+        RedirectType.replace
+      )
+    } else if (result instanceof Error) {
       redirect('/login?authError=500', RedirectType.replace)
+    } else {
+      cookies().set('token', await result.text())
+      redirect(DEFAULT_ROUTE)
     }
   }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,8 +1,6 @@
 import { Card, CardBody, Flex } from '@chakra-ui/react'
 import LoginForm from '@/components/login/LoginForm'
 import { RedirectType, redirect } from 'next/navigation'
-import { getAuthToken } from '@/utils/auth-util'
-import { verifyToken } from '@/server-utils/jwt-utils'
 import { DEFAULT_ROUTE } from '@/app/default-route'
 import { apiFetch } from '@/server-utils/resource-api-util'
 import { cookies } from 'next/headers'
@@ -10,19 +8,6 @@ import { FetchError } from '@/utils/fetch-utils'
 import { Credentials } from '@/types/login-types'
 
 export default async function Login() {
-  const authToken = getAuthToken()
-  if (authToken && (await verifyToken(authToken))) {
-    /*
-     * This is to prevent a weird UX of still being able to access the login screen
-     * even though the user is already authenticated
-     */
-    redirect(DEFAULT_ROUTE, RedirectType.replace)
-  }
-
-  if (authToken) {
-    cookies().delete('token')
-  }
-
   async function authenticate(credentials: Credentials) {
     'use server'
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -24,13 +24,10 @@ export default async function Login() {
       redirect(DEFAULT_ROUTE)
     } catch (e) {
       if (e instanceof FetchError) {
-        redirect(
-          `/login?redirectError=${e.response.status}`,
-          RedirectType.replace
-        )
+        redirect(`/login?authError=${e.response.status}`, RedirectType.replace)
       }
 
-      redirect('/login?redirectError=500', RedirectType.replace)
+      redirect('/login?authError=500', RedirectType.replace)
     }
   }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -19,6 +19,10 @@ export default async function Login() {
     redirect(DEFAULT_ROUTE, RedirectType.replace)
   }
 
+  if (authToken) {
+    cookies().delete('token')
+  }
+
   async function authenticate(credentials: Credentials) {
     'use server'
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,0 @@
-import { RedirectType, redirect } from 'next/navigation'
-
-export default function Home() {
-  redirect('/login', RedirectType.replace)
-}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from 'next/navigation'
+import { RedirectType, redirect } from 'next/navigation'
 
 export default function Home() {
-  redirect('/login')
+  redirect('/login', RedirectType.replace)
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { verifyToken } from '@/server-utils/jwt-utils'
 import { NextRequest, NextResponse } from 'next/server'
-import UrlPattern from 'url-pattern'
+import { DEFAULT_ROUTE } from './app/default-route'
 
 function redirect(
   { nextUrl: { protocol, host } }: NextRequest,
@@ -27,14 +27,6 @@ export const config = {
   ],
 }
 
-function buildPatterns(routeStrings: string[]) {
-  return routeStrings.map((route) => new UrlPattern(route))
-}
-const PUBLIC_ROUTES = buildPatterns(['/', '/login'])
-function isRoutePublic({ nextUrl: { pathname } }: NextRequest) {
-  return PUBLIC_ROUTES.some((pattern) => pattern.match(pathname))
-}
-
 /*
  * We're combining middleware matchers with conditionals:
  * - middleware matchers are used to exclude stuff which aren't actual routes of the app
@@ -47,21 +39,29 @@ function isRoutePublic({ nextUrl: { pathname } }: NextRequest) {
  * using only the conditional code is buggy since it'll also end up blocking asset calls.
  */
 
-export default async function middleware(req: NextRequest) {
-  if (isRoutePublic(req)) {
+export default async function middleware(
+  req: NextRequest
+): Promise<NextResponse> {
+  const token = req.cookies.get('token')?.value
+  const isTokenValid = token && (await verifyToken(token))
+
+  const destPath = req.nextUrl.pathname
+  if (isTokenValid) {
+    if (destPath === '/' || destPath === '/login') {
+      return redirect(req, DEFAULT_ROUTE)
+    }
+
     return NextResponse.next()
   }
 
-  const token = req.cookies.get('token')?.value
-  if (!token) {
-    return redirect(req, '/login')
+  if (destPath === '/login') {
+    return NextResponse.next()
   }
 
-  if (!(await verifyToken(token))) {
-    const res = redirect(req, '/login')
+  const res = redirect(req, '/login')
+  if (token && !isTokenValid) {
     res.cookies.delete('token')
-    return res
   }
 
-  return NextResponse.next()
+  return res
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -58,7 +58,9 @@ export default async function middleware(req: NextRequest) {
   }
 
   if (!(await verifyToken(token))) {
-    return redirect(req, '/login')
+    const res = redirect(req, '/login')
+    res.cookies.delete('token')
+    return res
   }
 
   return NextResponse.next()

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,16 +2,14 @@ import { verifyToken } from '@/server-utils/jwt-utils'
 import { NextRequest, NextResponse } from 'next/server'
 import UrlPattern from 'url-pattern'
 
-function unauthenticatedRedirect(
+function redirect(
   { nextUrl: { protocol, host } }: NextRequest,
   path: string
 ): NextResponse {
   const base = `${protocol}//${host}`
   const url = new URL(path, base)
 
-  const res = NextResponse.redirect(url)
-  res.cookies.delete('token')
-  return res
+  return NextResponse.redirect(url)
 }
 
 export const config = {
@@ -56,11 +54,11 @@ export default async function middleware(req: NextRequest) {
 
   const token = req.cookies.get('token')?.value
   if (!token) {
-    return unauthenticatedRedirect(req, '/login')
+    return redirect(req, '/login')
   }
 
   if (!(await verifyToken(token))) {
-    return unauthenticatedRedirect(req, '/login')
+    return redirect(req, '/login')
   }
 
   return NextResponse.next()

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -54,11 +54,9 @@ export default async function middleware(
     return NextResponse.next()
   }
 
-  if (destPath === '/login') {
-    return NextResponse.next()
-  }
+  const res =
+    destPath === '/login' ? NextResponse.next() : redirect(req, '/login')
 
-  const res = redirect(req, '/login')
   if (token && !isTokenValid) {
     res.cookies.delete('token')
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,14 +2,16 @@ import { verifyToken } from '@/server-utils/jwt-utils'
 import { NextRequest, NextResponse } from 'next/server'
 import UrlPattern from 'url-pattern'
 
-function redirect(
+function unauthenticatedRedirect(
   { nextUrl: { protocol, host } }: NextRequest,
   path: string
 ): NextResponse {
   const base = `${protocol}//${host}`
   const url = new URL(path, base)
 
-  return NextResponse.redirect(url)
+  const res = NextResponse.redirect(url)
+  res.cookies.delete('token')
+  return res
 }
 
 export const config = {
@@ -54,11 +56,11 @@ export default async function middleware(req: NextRequest) {
 
   const token = req.cookies.get('token')?.value
   if (!token) {
-    return redirect(req, '/login')
+    return unauthenticatedRedirect(req, '/login')
   }
 
   if (!(await verifyToken(token))) {
-    return redirect(req, '/login')
+    return unauthenticatedRedirect(req, '/login')
   }
 
   return NextResponse.next()


### PR DESCRIPTION
Organic test steps:
1. Log in and navigate to a protected route (say /billing/create)
2. Wait for session to invalidate
3. Reload page. You will be redirected to the login page
4. Try to log in with the correct credentials

Expected: you will be able to log in
Actual: you will not be able to log in

Dev replication test steps:
Force step 2 by going to the dev tools -> application tab -> cookies -> change the value of 'token' to something like 'test'